### PR TITLE
feat[sutstat]: request args, response status range

### DIFF
--- a/src/systemstat/sutstat.py
+++ b/src/systemstat/sutstat.py
@@ -1,15 +1,30 @@
+import argparse
+import ast
 import logging
 import requests
 import sys
 
 from . import systemstat
+from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
 
 class SutStat(systemstat.SystemStat):
-    def __init__(self, url="http://localhost:6969", sleep=1.0, wait=30, **kwargs):
+    def __init__(
+        self,
+        url="http://localhost:6969",
+        request_args={},
+        response_status_min=100,
+        response_status_max=599,
+        sleep=1.0,
+        wait=30,
+        **kwargs,
+    ):
         super(SutStat, self).__init__(sleep=sleep, wait=wait, **kwargs)
 
         self._url = url
+        self._request_args = request_args
+        self._response_status_min = response_status_min
+        self._response_status_max = response_status_max
 
         self.logger = logging.getLogger(__name__)
 
@@ -20,15 +35,21 @@ class SutStat(systemstat.SystemStat):
 
         ping_url = self._url
 
+        if "verify" in self._request_args and self._request_args["verify"] is False:
+            requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
+
         try:
             # query the system to see if it is up.
-            response = requests.get(ping_url)
+            response = requests.get(ping_url, **self._request_args)
         except requests.exceptions.ConnectionError:
             self.logger.info("waiting for sut server to respond at {}".format(ping_url))
             # wait and poll again
             return False
 
-        if response.status_code == 200:
+        if (
+            response.status_code >= self._response_status_min
+            and response.status_code <= self._response_status_max
+        ):
             # system is up
             self.logger.info("System under test is up at {}".format(ping_url))
             return True
@@ -47,11 +68,57 @@ class SutStat(systemstat.SystemStat):
         return False
 
 
+class DictArgAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+
+        # get data that was previously saved at this destination.
+        # if there was no data, start with an empty dictionary.
+        d = getattr(namespace, self.dest)
+        if d is None:
+            d = {}
+
+        # check the format of the value
+        if len(values) <= 2:
+            raise ValueError(f'expected form "KEY=VALUE": {values}')
+
+        # parse the value and save the key and value in the destination.
+        k, v = values.split("=", 1)
+        d[k] = ast.literal_eval(v)
+        setattr(namespace, self.dest, d)
+
+
 class SutStatTool(SutStat, systemstat.SystemStatTool):
     def __init__(self, logfile="sutstat.log", **kwargs):
         super(SutStatTool, self).__init__(logfile=logfile)
 
         self.logger = logging.getLogger(__name__)
+
+        self.command_parser.add_argument(
+            "--request-arg",
+            help="additional argument for the http request in the form of 'KEY=VALUE'",
+            metavar="KEY=VALUE",
+            dest="request_args",
+            action=DictArgAction,
+            default={},
+        )
+
+        self.command_parser.add_argument(
+            "--response-status-max",
+            help="maximum response status code for the request to be considered successful (range 100-599)",
+            action="store",
+            dest="response_status_max",
+            default=599,
+            type=int,
+        )
+
+        self.command_parser.add_argument(
+            "--response-status-min",
+            help="minimum response status code for the request to be considered successful (range 100-599)",
+            action="store",
+            dest="response_status_min",
+            default=100,
+            type=int,
+        )
 
         self.command_parser.add_argument(
             "--url",
@@ -67,6 +134,9 @@ class SutStatTool(SutStat, systemstat.SystemStatTool):
 
         # override SutStat class defaults with command line defaults
         self._url = self.options.url
+        self._request_args = self.options.request_args
+        self._response_status_min = self.options.response_status_min
+        self._response_status_max = self.options.response_status_max
 
         # start logging
         self.start_logging()


### PR DESCRIPTION
Update sutstat to allow the caller to set additional arguments to the GET request sent to see if the system is up (or ready).
Through the command line, users can now specify additional request arguments with the `--request-arg KEY=VALUE` flag. Arguments will be collected in a dictionary and passed into the call to `requests.get()`.

This example disables verification of certificates:
```bash
sutstat --url https://12.34.45.78 --request-arg verify=False
```

Eventually, that translates into a call similar to:
```python
requests.get("https://12.34.56.78", verify=False)
```
where the `False` from the command line ends up being a python boolean False value. To pass a string, try something like:
```python
--request-arg 'key="value"'
```
or
```python
--request-arg "key=\"value\""
```

Also including two new flags to tune the values of the response status code that are considered successful. The flag `--response-status-min` allows the user to set the minimum status code that is accepted as success. The flag `--response-status-max` allows the user to set the maximum status code that is accepted as successful. Together, they allow the user to set an inclusive range of status codes that are considered successful.

For example, to accept status codes from 200-299 as successful:
```bash
sutstat --response-status-min 200 --response-status-max 299
```

The default is to accept any status code from 100-599 as successful.